### PR TITLE
Fix agent service naming

### DIFF
--- a/smartcs-web-adapter/src/main/java/com/leyue/smartcs/web/agent/AdminAgentController.java
+++ b/smartcs-web-adapter/src/main/java/com/leyue/smartcs/web/agent/AdminAgentController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.alibaba.cola.dto.MultiResponse;
-import com.leyue.smartcs.api.AgentServic;
+import com.leyue.smartcs.api.AgentService;
 import com.leyue.smartcs.dto.AgentServiceListQry;
 import com.leyue.smartcs.dto.data.AgentServiceDTO;
 
@@ -18,7 +18,7 @@ import com.leyue.smartcs.dto.data.AgentServiceDTO;
 public class AdminAgentController {
     
     @Autowired
-    private AgentServic agentServic;
+    private AgentService agentService;
     
     /**
      * 获取客服列表
@@ -27,6 +27,6 @@ public class AdminAgentController {
      */
     @GetMapping("/list")
     public MultiResponse<AgentServiceDTO> getAgentList(AgentServiceListQry qry) {
-        return agentServic.getAgentList(qry);
+        return agentService.getAgentList(qry);
     }
 }

--- a/smartcs-web-app/src/main/java/com/leyue/smartcs/customer/serviceimpl/CustomerServiceServiceImpl.java
+++ b/smartcs-web-app/src/main/java/com/leyue/smartcs/customer/serviceimpl/CustomerServiceServiceImpl.java
@@ -1,7 +1,7 @@
 package com.leyue.smartcs.customer.serviceimpl;
 
 import com.alibaba.cola.dto.MultiResponse;
-import com.leyue.smartcs.api.AgentServic;
+import com.leyue.smartcs.api.AgentService;
 import com.leyue.smartcs.domain.customer.CustomerService;
 import com.leyue.smartcs.domain.customer.gateway.AgentGateway;
 import com.leyue.smartcs.domain.customer.gateway.AgentGateway.CustomerServiceStatistics;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
  * 客服管理服务实现
  */
 @Service
-public class CustomerServiceServiceImpl implements AgentServic {
+public class CustomerServiceServiceImpl implements AgentService {
     
     @Autowired
     private AgentGateway agentGateway;

--- a/smartcs-web-client/src/main/java/com/leyue/smartcs/api/AgentService.java
+++ b/smartcs-web-client/src/main/java/com/leyue/smartcs/api/AgentService.java
@@ -7,7 +7,7 @@ import com.leyue.smartcs.dto.data.AgentServiceDTO;
 /**
  * 客服管理API接口
  */
-public interface AgentServic {
+public interface AgentService {
     
     /**
      * 获取客服列表


### PR DESCRIPTION
## Summary
- rename `AgentServic` to `AgentService`
- update controller and service implementation to use the new interface name

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef78ec70c832daab843a4b5569a9f